### PR TITLE
Fix doc typo.

### DIFF
--- a/spring-geode-docs/src/docs/asciidoc/appendix.adoc
+++ b/spring-geode-docs/src/docs/asciidoc/appendix.adoc
@@ -42,7 +42,7 @@ class with the following, recommended JRE command-line options:
 .Server 1 run profile configuration
 [source,txt]
 ----
--server -ea -Dspring.profiles-active=
+-server -ea -Dspring.profiles.active=
 ----
 
 Start the class.  You should see similar output:


### PR DESCRIPTION
An user following the documentation step by step will fail to get a cluster up and running because of this particular typo: the `"loner"` profile is not activated and, so, the second server will also try to start a locator, failing with the `BindException: Address already in use (Bind failed)`. The document referenced the property `spring.profiles-active` and it doesn't exist, it should be `spring.profiles.active` instead.