### PR TITLE
Use a different policy for property overrides

### DIFF
--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/auth/ClientSecurityAutoConfigurationUnitTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/auth/ClientSecurityAutoConfigurationUnitTests.java
@@ -16,6 +16,23 @@
 
 package org.springframework.geode.boot.autoconfigure.security.auth;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.Test;
+
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.geode.boot.autoconfigure.ClientSecurityAutoConfiguration;
+import org.springframework.geode.boot.autoconfigure.ClientSecurityAutoConfiguration.AutoConfiguredCloudSecurityEnvironmentPostProcessor;
+import org.springframework.mock.env.MockEnvironment;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -27,17 +44,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.util.Properties;
-
-import org.junit.Test;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MutablePropertySources;
-import org.springframework.core.env.PropertiesPropertySource;
-import org.springframework.core.env.PropertySource;
-import org.springframework.geode.boot.autoconfigure.ClientSecurityAutoConfiguration;
-import org.springframework.geode.boot.autoconfigure.ClientSecurityAutoConfiguration.AutoConfiguredCloudSecurityEnvironmentPostProcessor;
-import org.springframework.mock.env.MockEnvironment;
 
 /**
  * Unit Tests for {@link ClientSecurityAutoConfiguration}.
@@ -54,22 +60,24 @@ public class ClientSecurityAutoConfigurationUnitTests {
 	@Test
 	public void clientSecurityIsEnabledWhenEnablePropertyIsTrueAndCloudFoundryIsActive() {
 
-		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor =
-			spy(new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
+		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor = spy(
+				new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
 
-		doNothing().when(environmentPostProcessor).configureSecurityContext(any(ConfigurableEnvironment.class));
+		doNothing().when(environmentPostProcessor)
+				.configureSecurityContext(any(ConfigurableEnvironment.class));
 
 		ConfigurableEnvironment mockEnvironment = mock(ConfigurableEnvironment.class);
 
 		when(mockEnvironment.containsProperty(eq("VCAP_APPLICATION"))).thenReturn(true);
 
-		when(mockEnvironment.getProperty(eq(ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
-			eq(Boolean.class), eq(true))).thenReturn(true);
+		when(mockEnvironment.getProperty(eq(
+				ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
+				eq(Boolean.class), eq(true))).thenReturn(true);
 
 		environmentPostProcessor.postProcessEnvironment(mockEnvironment, null);
 
-		verify(mockEnvironment, times(1))
-			.getProperty(eq(ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
+		verify(mockEnvironment, times(1)).getProperty(eq(
+				ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
 				eq(Boolean.class), eq(true));
 
 		verify(mockEnvironment, times(1)).containsProperty(eq("VCAP_APPLICATION"));
@@ -77,16 +85,17 @@ public class ClientSecurityAutoConfigurationUnitTests {
 		verify(mockEnvironment, never()).containsProperty(eq("VCAP_SERVICES"));
 
 		verify(environmentPostProcessor, times(1))
-			.configureSecurityContext(eq(mockEnvironment));
+				.configureSecurityContext(eq(mockEnvironment));
 	}
 
 	@Test
 	public void clientSecurityIsEnabledWhenEnablePropertyIsUnsetAndCloudFoundryIsActive() {
 
-		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor =
-			spy(new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
+		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor = spy(
+				new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
 
-		doNothing().when(environmentPostProcessor).configureSecurityContext(any(ConfigurableEnvironment.class));
+		doNothing().when(environmentPostProcessor)
+				.configureSecurityContext(any(ConfigurableEnvironment.class));
 
 		ConfigurableEnvironment mockEnvironment = spy(new MockEnvironment());
 
@@ -94,68 +103,75 @@ public class ClientSecurityAutoConfigurationUnitTests {
 
 		environmentPostProcessor.postProcessEnvironment(mockEnvironment, null);
 
-		verify(mockEnvironment, times(1))
-			.getProperty(eq(ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
+		verify(mockEnvironment, times(1)).getProperty(eq(
+				ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
 				eq(Boolean.class), eq(true));
 
 		verify(mockEnvironment, times(1)).containsProperty(eq("VCAP_APPLICATION"));
 		verify(mockEnvironment, times(1)).containsProperty(eq("VCAP_SERVICES"));
 
-		verify(environmentPostProcessor, times(1)).configureSecurityContext(eq(mockEnvironment));
+		verify(environmentPostProcessor, times(1))
+				.configureSecurityContext(eq(mockEnvironment));
 	}
 
 	@Test
 	public void clientSecurityIsDisabledWhenEnablePropertyIsFalseAndCloudFoundryIsActive() {
 
-		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor =
-			spy(new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
+		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor = spy(
+				new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
 
-		doNothing().when(environmentPostProcessor).configureSecurityContext(any(ConfigurableEnvironment.class));
+		doNothing().when(environmentPostProcessor)
+				.configureSecurityContext(any(ConfigurableEnvironment.class));
 
 		ConfigurableEnvironment mockEnvironment = mock(ConfigurableEnvironment.class);
 
 		when(mockEnvironment.containsProperty(eq("VCAP_APPLICATION"))).thenReturn(true);
 		when(mockEnvironment.containsProperty(eq("VCAP_SERVICES"))).thenReturn(true);
 
-		when(mockEnvironment.getProperty(eq(ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
-			eq(Boolean.class), eq(true))).thenReturn(false);
+		when(mockEnvironment.getProperty(eq(
+				ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
+				eq(Boolean.class), eq(true))).thenReturn(false);
 
 		environmentPostProcessor.postProcessEnvironment(mockEnvironment, null);
 
-		verify(mockEnvironment, times(1))
-			.getProperty(eq(ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
+		verify(mockEnvironment, times(1)).getProperty(eq(
+				ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
 				eq(Boolean.class), eq(true));
 
 		verify(mockEnvironment, never()).containsProperty(eq("VCAP_APPLICATION"));
 		verify(mockEnvironment, never()).containsProperty(eq("VCAP_SERVICES"));
-		verify(environmentPostProcessor, never()).configureSecurityContext(eq(mockEnvironment));
+		verify(environmentPostProcessor, never())
+				.configureSecurityContext(eq(mockEnvironment));
 	}
 
 	@Test
 	public void clientSecurityIsDisabledWhenEnablePropertyIsTrueAndCloudFoundryIsInactive() {
 
-		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor =
-			spy(new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
+		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor = spy(
+				new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
 
-		doNothing().when(environmentPostProcessor).configureSecurityContext(any(ConfigurableEnvironment.class));
+		doNothing().when(environmentPostProcessor)
+				.configureSecurityContext(any(ConfigurableEnvironment.class));
 
 		ConfigurableEnvironment mockEnvironment = mock(ConfigurableEnvironment.class);
 
 		when(mockEnvironment.containsProperty(eq("VCAP_APPLICATION"))).thenReturn(false);
 		when(mockEnvironment.containsProperty(eq("VCAP_SERVICES"))).thenReturn(false);
 
-		when(mockEnvironment.getProperty(eq(ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
-			eq(Boolean.class), eq(true))).thenReturn(true);
+		when(mockEnvironment.getProperty(eq(
+				ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
+				eq(Boolean.class), eq(true))).thenReturn(true);
 
 		environmentPostProcessor.postProcessEnvironment(mockEnvironment, null);
 
-		verify(mockEnvironment, times(1))
-			.getProperty(eq(ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
+		verify(mockEnvironment, times(1)).getProperty(eq(
+				ClientSecurityAutoConfiguration.CLOUD_SECURITY_ENVIRONMENT_POST_PROCESSOR_ENABLED_PROPERTY),
 				eq(Boolean.class), eq(true));
 
 		verify(mockEnvironment, times(1)).containsProperty(eq("VCAP_APPLICATION"));
 		verify(mockEnvironment, times(1)).containsProperty(eq("VCAP_SERVICES"));
-		verify(environmentPostProcessor, never()).configureSecurityContext(eq(mockEnvironment));
+		verify(environmentPostProcessor, never())
+				.configureSecurityContext(eq(mockEnvironment));
 	}
 
 	@Test
@@ -167,19 +183,31 @@ public class ClientSecurityAutoConfigurationUnitTests {
 		Properties vcapProperties = new Properties();
 
 		vcapProperties.setProperty("vcap.application.name", "TestApp");
-		vcapProperties.setProperty("vcap.application.uris", "test-app.apps.cloud.skullbox.com");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.locators", "boombox[10334],skullbox[10334]");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.urls.gfsh", "https://cloud.skullbox.com:8080/gemfire/v1");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.urls.pulse", "https://cloud.skullbox.com:8080/pulse");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].username", "Abuser");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].password", "p@55w0rd");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].roles", "cluster_developer");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].username", "Master");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].password", "p@$$w0rd");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].roles", "cluster_operator");
-		vcapProperties.setProperty("vcap.services.test-pcc.tags", "gemfire,cloudcache,test,geode");
+		vcapProperties.setProperty("vcap.application.uris",
+				"test-app.apps.cloud.skullbox.com");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.locators",
+				"boombox[10334],skullbox[10334]");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.urls.gfsh",
+				"https://cloud.skullbox.com:8080/gemfire/v1");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.urls.pulse",
+				"https://cloud.skullbox.com:8080/pulse");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].username",
+				"Abuser");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].password",
+				"p@55w0rd");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].roles",
+				"cluster_developer");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].username",
+				"Master");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].password",
+				"p@$$w0rd");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].roles",
+				"cluster_operator");
+		vcapProperties.setProperty("vcap.services.test-pcc.tags",
+				"gemfire,cloudcache,test,geode");
 
-		PropertySource vcapPropertySource = new PropertiesPropertySource("vcap", vcapProperties);
+		PropertySource vcapPropertySource = new PropertiesPropertySource("vcap",
+				vcapProperties);
 
 		MutablePropertySources propertySources = new MutablePropertySources();
 
@@ -187,8 +215,8 @@ public class ClientSecurityAutoConfigurationUnitTests {
 
 		when(mockEnvironment.getPropertySources()).thenReturn(propertySources);
 
-		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor =
-			spy(new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
+		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor = spy(
+				new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
 
 		environmentPostProcessor.configureSecurityContext(mockEnvironment);
 
@@ -196,69 +224,89 @@ public class ClientSecurityAutoConfigurationUnitTests {
 
 		assertThat(propertySources.contains("boot.data.gemfire.cloudcache")).isTrue();
 
-		PropertySource propertySource = propertySources.get("boot.data.gemfire.cloudcache");
+		PropertySource propertySource = propertySources
+				.get("boot.data.gemfire.cloudcache");
 
 		assertThat(propertySource).isNotNull();
 		assertThat(propertySource.getName()).isEqualTo("boot.data.gemfire.cloudcache");
-		assertThat(propertySource.getProperty("spring.data.gemfire.security.username")).isEqualTo("Master");
-		assertThat(propertySource.getProperty("spring.data.gemfire.security.password")).isEqualTo("p@$$w0rd");
+		assertThat(propertySource.getProperty("spring.data.gemfire.security.username"))
+				.isEqualTo("Master");
+		assertThat(propertySource.getProperty("spring.data.gemfire.security.password"))
+				.isEqualTo("p@$$w0rd");
 		assertThat(propertySource.getProperty("spring.data.gemfire.pool.locators"))
-			.isEqualTo("boombox[10334],skullbox[10334]");
-		assertThat(propertySource.getProperty("spring.data.gemfire.management.use-http")).isEqualTo("true");
-		assertThat(propertySource.getProperty("spring.data.gemfire.management.http.host")).isEqualTo("cloud.skullbox.com");
-		assertThat(propertySource.getProperty("spring.data.gemfire.management.http.port")).isEqualTo("8080");
+				.isEqualTo("boombox[10334],skullbox[10334]");
+		assertThat(propertySource.getProperty("spring.data.gemfire.management.use-http"))
+				.isEqualTo("true");
+		assertThat(propertySource.getProperty("spring.data.gemfire.management.http.host"))
+				.isEqualTo("cloud.skullbox.com");
+		assertThat(propertySource.getProperty("spring.data.gemfire.management.http.port"))
+				.isEqualTo("8080");
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
 	public void configuresSecurityContextWithLocatorsOnly() {
 
-		ConfigurableEnvironment mockEnvironment = mock(ConfigurableEnvironment.class);
+		ConfigurableEnvironment mockEnvironment = new StandardEnvironment();
+		MutablePropertySources propertySources = mockEnvironment.getPropertySources();
 
-		when(mockEnvironment.containsProperty("spring.data.gemfire.security.username")).thenReturn(true);
-		when(mockEnvironment.containsProperty("spring.data.gemfire.security.password")).thenReturn(true);
+		Map<String, Object> user = new HashMap<>();
+		propertySources.addFirst(new MapPropertySource("userProps", user));
+		user.put("spring.data.gemfire.security.username", "preset");
+		user.put("spring.data.gemfire.security.password", "password");
 
 		Properties vcapProperties = new Properties();
 
 		vcapProperties.setProperty("vcap.application.name", "TestApp");
-		vcapProperties.setProperty("vcap.application.uris", "test-app.apps.cloud.skullbox.com");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.locators", "boombox[10334],skullbox[10334]");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.urls.pulse", "https://cloud.skullbox.com:8080/pulse");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].username", "Abuser");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].password", "p@55w0rd");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].roles", "cluster_developer");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].username", "Master");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].password", "p@$$w0rd");
-		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].roles", "cluster_operator");
-		vcapProperties.setProperty("vcap.services.test-pcc.tags", "gemfire,cloudcache,test");
+		vcapProperties.setProperty("vcap.application.uris",
+				"test-app.apps.cloud.skullbox.com");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.locators",
+				"boombox[10334],skullbox[10334]");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.urls.pulse",
+				"https://cloud.skullbox.com:8080/pulse");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].username",
+				"Abuser");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].password",
+				"p@55w0rd");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[0].roles",
+				"cluster_developer");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].username",
+				"Master");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].password",
+				"p@$$w0rd");
+		vcapProperties.setProperty("vcap.services.test-pcc.credentials.users[1].roles",
+				"cluster_operator");
+		vcapProperties.setProperty("vcap.services.test-pcc.tags",
+				"gemfire,cloudcache,test");
 
-		PropertySource vcapPropertySource = new PropertiesPropertySource("vcap", vcapProperties);
-
-		MutablePropertySources propertySources = new MutablePropertySources();
+		PropertySource vcapPropertySource = new PropertiesPropertySource("vcap",
+				vcapProperties);
 
 		propertySources.addFirst(vcapPropertySource);
 
-		when(mockEnvironment.getPropertySources()).thenReturn(propertySources);
-
-		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor =
-			spy(new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
+		AutoConfiguredCloudSecurityEnvironmentPostProcessor environmentPostProcessor = spy(
+				new AutoConfiguredCloudSecurityEnvironmentPostProcessor());
 
 		environmentPostProcessor.configureSecurityContext(mockEnvironment);
 
-		verify(mockEnvironment, times(2)).getPropertySources();
-
 		assertThat(propertySources.contains("boot.data.gemfire.cloudcache")).isTrue();
 
-		PropertySource propertySource = propertySources.get("boot.data.gemfire.cloudcache");
+		PropertySource propertySource = propertySources
+				.get("boot.data.gemfire.cloudcache");
 
 		assertThat(propertySource).isNotNull();
 		assertThat(propertySource.getName()).isEqualTo("boot.data.gemfire.cloudcache");
-		assertThat(propertySource.containsProperty("spring.data.gemfire.security.username")).isFalse();
-		assertThat(propertySource.containsProperty("spring.data.gemfire.security.password")).isFalse();
+		assertThat(propertySource.getProperty("spring.data.gemfire.security.username"))
+				.isEqualTo("Master");
+		assertThat(mockEnvironment.getProperty("spring.data.gemfire.security.username"))
+				.isEqualTo("preset");
 		assertThat(propertySource.getProperty("spring.data.gemfire.pool.locators"))
-			.isEqualTo("boombox[10334],skullbox[10334]");
-		assertThat(propertySource.containsProperty("spring.data.gemfire.management.use-http")).isFalse();
-		assertThat(propertySource.containsProperty("spring.data.gemfire.management.http.host")).isFalse();
-		assertThat(propertySource.containsProperty("spring.data.gemfire.management.http.port")).isFalse();
+				.isEqualTo("boombox[10334],skullbox[10334]");
+		assertThat(propertySource
+				.containsProperty("spring.data.gemfire.management.use-http")).isFalse();
+		assertThat(propertySource
+				.containsProperty("spring.data.gemfire.management.http.host")).isFalse();
+		assertThat(propertySource
+				.containsProperty("spring.data.gemfire.management.http.port")).isFalse();
 	}
 }


### PR DESCRIPTION
Normally in the `Environment` it is better to let user-defined
properties take precedence, rather than trying to simply omit
them. This change makes the `ClientSecurityAutoConfiguration` rely
on that existing feature, rather than trying to inspect the property
sources manually and add guess which properties are set.

See #21