### PR TITLE
URL Cleanup

### DIFF
--- a/spring-geode-docs/spring-geode-docs.gradle
+++ b/spring-geode-docs/spring-geode-docs.gradle
@@ -43,12 +43,12 @@ asciidoctor {
 javadoc {
 	configure(options) {
 		links = [
-			"http://docs.spring.io/spring/docs/current/javadoc-api/",
+			"https://docs.spring.io/spring/docs/current/javadoc-api/",
 			"https://docs.spring.io/spring-boot/docs/current/api/",
-			"http://docs.spring.io/spring-data/commons/docs/current/api/",
+			"https://docs.spring.io/spring-data/commons/docs/current/api/",
 			"https://docs.spring.io/spring-data/geode/docs/current/api/",
-			"http://docs.spring.io/spring-boot-data-geode/docs/${project.version}/api/",
-			"http://geode.apache.org/releases/latest/javadoc/",
+			"https://docs.spring.io/spring-boot-data-geode/docs/${project.version}/api/",
+			"https://geode.apache.org/releases/latest/javadoc/",
 		]
 	}
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://docs.spring.io/spring-boot-data-geode/docs/ (301) migrated to:  
  https://docs.spring.io/spring-boot-data-geode/docs/ ([https](https://docs.spring.io/spring-boot-data-geode/docs/) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://docs.spring.io/spring-data/commons/docs/current/api/ migrated to:  
  https://docs.spring.io/spring-data/commons/docs/current/api/ ([https](https://docs.spring.io/spring-data/commons/docs/current/api/) result 200).
* http://docs.spring.io/spring/docs/current/javadoc-api/ migrated to:  
  https://docs.spring.io/spring/docs/current/javadoc-api/ ([https](https://docs.spring.io/spring/docs/current/javadoc-api/) result 200).
* http://geode.apache.org/releases/latest/javadoc/ migrated to:  
  https://geode.apache.org/releases/latest/javadoc/ ([https](https://geode.apache.org/releases/latest/javadoc/) result 200).