### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.adoc
+++ b/README.adoc
@@ -69,4 +69,4 @@ By participating, you  are expected to uphold this code. Please report unaccepta
 == License
 
 _Spring Boot_, _Spring Boot for Apache Geode_ and _Spring Boot for Pivotal GemFire_ is Open Source Software
-released under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].
+released under the https://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].

--- a/samples/boot/actuator/spring-geode-sample-boot-actuator.gradle
+++ b/samples/boot/actuator/spring-geode-sample-boot-actuator.gradle
@@ -4,8 +4,7 @@ description = "Spring Geode Sample demonstrating the use of Spring Boot Actuator
 
 dependencies {
 
-	compile project(":spring-geode-starter")
-	compile project(":spring-geode-actuator-autoconfigure")
+	compile project(":spring-geode-starter-actuator")
 
 	compile ("org.springframework.boot:spring-boot-starter-web") {
 		exclude group: "org.springframework.boot", module: "spring-boot-starter-logging"

--- a/samples/boot/actuator/spring-geode-sample-boot-actuator.gradle
+++ b/samples/boot/actuator/spring-geode-sample-boot-actuator.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'io.spring.convention.spring-sample-boot'
+
+description = "Spring Geode Sample demonstrating the use of Spring Boot Actuator with Apache Geode."
+
+dependencies {
+
+	compile project(":spring-geode-starter")
+	compile project(":spring-geode-actuator-autoconfigure")
+
+	compile ("org.springframework.boot:spring-boot-starter-web") {
+		exclude group: "org.springframework.boot", module: "spring-boot-starter-logging"
+	}
+
+	compile "org.springframework.data:spring-data-geode-test"
+
+	runtime "org.springframework.shell:spring-shell"
+
+	runtime ("org.springframework.boot:spring-boot-starter-jetty") {
+		exclude group: "org.springframework.boot", module: "spring-boot-starter-logging"
+	}
+
+}

--- a/samples/boot/actuator/spring-geode-sample-boot-actuator.gradle
+++ b/samples/boot/actuator/spring-geode-sample-boot-actuator.gradle
@@ -20,3 +20,7 @@ dependencies {
 	}
 
 }
+
+bootJar {
+	mainClassName = 'example.app.temp.geode.client.BootGeodeClientApplication'
+}

--- a/samples/boot/actuator/src/main/java/example/app/temp/event/BoilingTemperatureEvent.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/event/BoilingTemperatureEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/actuator/src/main/java/example/app/temp/event/BoilingTemperatureEvent.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/event/BoilingTemperatureEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package example.app.temp.event;
+
+import example.app.temp.model.TemperatureReading;
+
+@SuppressWarnings("unused")
+public class BoilingTemperatureEvent extends TemperatureEvent {
+
+	public BoilingTemperatureEvent(Object source, TemperatureReading temperatureReading) {
+		super(source, temperatureReading);
+	}
+}

--- a/samples/boot/actuator/src/main/java/example/app/temp/event/FreezingTemperatureEvent.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/event/FreezingTemperatureEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/actuator/src/main/java/example/app/temp/event/FreezingTemperatureEvent.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/event/FreezingTemperatureEvent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package example.app.temp.event;
+
+import example.app.temp.model.TemperatureReading;
+
+@SuppressWarnings("unused")
+public class FreezingTemperatureEvent extends TemperatureEvent {
+
+	public FreezingTemperatureEvent(Object source, TemperatureReading temperatureReading) {
+		super(source, temperatureReading);
+	}
+}

--- a/samples/boot/actuator/src/main/java/example/app/temp/event/TemperatureEvent.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/event/TemperatureEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/actuator/src/main/java/example/app/temp/event/TemperatureEvent.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/event/TemperatureEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package example.app.temp.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import example.app.temp.model.TemperatureReading;
+import lombok.Getter;
+
+public class TemperatureEvent extends ApplicationEvent {
+
+	@Getter
+	private final TemperatureReading temperatureReading;
+
+	public TemperatureEvent(Object source, TemperatureReading temperatureReading) {
+
+		super(source);
+
+		this.temperatureReading = temperatureReading;
+	}
+}

--- a/samples/boot/actuator/src/main/java/example/app/temp/geode/client/BootGeodeClientApplication.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/geode/client/BootGeodeClientApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/actuator/src/main/java/example/app/temp/geode/client/BootGeodeClientApplication.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/geode/client/BootGeodeClientApplication.java
@@ -23,6 +23,8 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.gemfire.config.annotation.EnableEntityDefinedRegions;
+import org.springframework.geode.config.annotation.UseGroups;
+import org.springframework.geode.config.annotation.UseMemberName;
 
 import example.app.temp.event.BoilingTemperatureEvent;
 import example.app.temp.event.FreezingTemperatureEvent;
@@ -32,6 +34,8 @@ import example.app.temp.service.TemperatureMonitor;
 
 @SpringBootApplication
 @EnableEntityDefinedRegions(basePackageClasses = TemperatureReading.class)
+@UseGroups("TemperatureMonitors")
+@UseMemberName("TemperatureMonitoringService")
 @SuppressWarnings("unused")
 public class BootGeodeClientApplication {
 

--- a/samples/boot/actuator/src/main/java/example/app/temp/geode/client/BootGeodeClientApplication.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/geode/client/BootGeodeClientApplication.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package example.app.temp.geode.client;
+
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.gemfire.config.annotation.EnableEntityDefinedRegions;
+
+import example.app.temp.event.BoilingTemperatureEvent;
+import example.app.temp.event.FreezingTemperatureEvent;
+import example.app.temp.event.TemperatureEvent;
+import example.app.temp.model.TemperatureReading;
+import example.app.temp.service.TemperatureMonitor;
+
+@SpringBootApplication
+@EnableEntityDefinedRegions(basePackageClasses = TemperatureReading.class)
+@SuppressWarnings("unused")
+public class BootGeodeClientApplication {
+
+	public static void main(String[] args) {
+
+		new SpringApplicationBuilder(BootGeodeClientApplication.class)
+			.web(WebApplicationType.SERVLET)
+			.build()
+			.run(args);
+	}
+
+	@Bean
+	TemperatureMonitor temperatureMonitor(ApplicationEventPublisher applicationEventPublisher) {
+		return new TemperatureMonitor(applicationEventPublisher);
+	}
+
+	@EventListener(classes = { BoilingTemperatureEvent.class, FreezingTemperatureEvent.class })
+	public void temperatureEventHandler(TemperatureEvent temperatureEvent) {
+
+		System.err.printf("%1$s TEMPERATURE READING [%2$s]%n",
+			temperatureEvent instanceof BoilingTemperatureEvent ? "HOT" : "COLD",
+				temperatureEvent.getTemperatureReading());
+	}
+}

--- a/samples/boot/actuator/src/main/java/example/app/temp/geode/server/BootGeodeServerApplication.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/geode/server/BootGeodeServerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/actuator/src/main/java/example/app/temp/geode/server/BootGeodeServerApplication.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/geode/server/BootGeodeServerApplication.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package example.app.temp.geode.server;
+
+import org.apache.geode.cache.GemFireCache;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.data.gemfire.IndexFactoryBean;
+import org.springframework.data.gemfire.config.annotation.CacheServerApplication;
+import org.springframework.data.gemfire.config.annotation.EnableEntityDefinedRegions;
+import org.springframework.data.gemfire.repository.config.EnableGemfireRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import example.app.temp.model.TemperatureReading;
+import example.app.temp.repo.TemperatureReadingRepository;
+import example.app.temp.service.TemperatureSensor;
+
+@SpringBootApplication
+@CacheServerApplication(name = "TemperatureServiceServer")
+@EnableEntityDefinedRegions(basePackageClasses = TemperatureReading.class)
+@EnableGemfireRepositories(basePackageClasses = TemperatureReadingRepository.class)
+@EnableScheduling
+@SuppressWarnings("unused")
+public class BootGeodeServerApplication {
+
+	public static void main(String[] args) {
+
+		new SpringApplicationBuilder(BootGeodeServerApplication.class)
+			.web(WebApplicationType.SERVLET)
+			.build()
+			.run(args);
+	}
+
+	@Bean
+	TemperatureSensor temperatureSensor(TemperatureReadingRepository repository) {
+		return new TemperatureSensor(repository);
+	}
+
+	@Bean
+	@DependsOn("TemperatureReadings")
+	IndexFactoryBean temperatureReadingTemperatureIndex(GemFireCache gemfireCache) {
+
+		IndexFactoryBean temperatureTimestampIndex = new IndexFactoryBean();
+
+		temperatureTimestampIndex.setCache(gemfireCache);
+		temperatureTimestampIndex.setExpression("temperature");
+		temperatureTimestampIndex.setFrom("/TemperatureReadings");
+		temperatureTimestampIndex.setName("TemperatureReadingTemperatureIdx");
+
+		return temperatureTimestampIndex;
+	}
+
+	@Bean
+	@DependsOn("TemperatureReadings")
+	IndexFactoryBean temperatureReadingTimestampIndex(GemFireCache gemfireCache) {
+
+		IndexFactoryBean temperatureTimestampIndex = new IndexFactoryBean();
+
+		temperatureTimestampIndex.setCache(gemfireCache);
+		temperatureTimestampIndex.setExpression("timestamp");
+		temperatureTimestampIndex.setFrom("/TemperatureReadings");
+		temperatureTimestampIndex.setName("TemperatureReadingTimestampIdx");
+
+		return temperatureTimestampIndex;
+	}
+}

--- a/samples/boot/actuator/src/main/java/example/app/temp/model/TemperatureReading.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/model/TemperatureReading.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/actuator/src/main/java/example/app/temp/model/TemperatureReading.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/model/TemperatureReading.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package example.app.temp.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.gemfire.mapping.annotation.Region;
+
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@Region("TemperatureReadings")
+@RequiredArgsConstructor(staticName = "newTemperatureReading")
+@SuppressWarnings("unused")
+public class TemperatureReading {
+
+	private static final int BOILING_TEMPERATURE = 212;
+	private static final int FREEZING_TEMPERATURE = 32;
+
+	@Id
+	private Long timestamp = System.currentTimeMillis();
+
+	@NonNull
+	private Integer temperature;
+
+	@Transient
+	public boolean isBoiling() {
+
+		Integer temperature = getTemperature();
+
+		return temperature != null && temperature >= BOILING_TEMPERATURE;
+	}
+
+	@Transient
+	public boolean isNormal() {
+		return !(isBoiling() || isFreezing());
+	}
+
+	@Transient
+	public boolean isFreezing() {
+
+		Integer temperature = getTemperature();
+
+		return temperature != null && temperature <= FREEZING_TEMPERATURE;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%d °F", getTemperature());
+	}
+}

--- a/samples/boot/actuator/src/main/java/example/app/temp/repo/TemperatureReadingRepository.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/repo/TemperatureReadingRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/actuator/src/main/java/example/app/temp/repo/TemperatureReadingRepository.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/repo/TemperatureReadingRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package example.app.temp.repo;
+
+import java.util.List;
+
+import org.springframework.data.gemfire.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+import example.app.temp.model.TemperatureReading;
+
+@SuppressWarnings("unused")
+public interface TemperatureReadingRepository extends CrudRepository<TemperatureReading, Long> {
+
+	List<TemperatureReading> findByTimestampGreaterThanAndTimestampLessThan(Long timestampLowerBound,
+		Long timestampUpperBound);
+
+	@Query("SELECT count(*) FROM /TemperatureReadings WHERE temperature >= 212")
+	Integer countBoilingTemperatureReadings();
+
+	@Query("SELECT count(*) FROM /TemperatureReadings WHERE temperature <= 32")
+	Integer countFreezingTemperatureReadings();
+
+}

--- a/samples/boot/actuator/src/main/java/example/app/temp/service/TemperatureMonitor.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/service/TemperatureMonitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/actuator/src/main/java/example/app/temp/service/TemperatureMonitor.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/service/TemperatureMonitor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package example.app.temp.service;
+
+import java.util.Optional;
+
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.shiro.util.Assert;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.gemfire.listener.annotation.ContinuousQuery;
+import org.springframework.stereotype.Service;
+
+import example.app.temp.event.BoilingTemperatureEvent;
+import example.app.temp.event.FreezingTemperatureEvent;
+import example.app.temp.model.TemperatureReading;
+
+@Service
+@SuppressWarnings("unused")
+public class TemperatureMonitor {
+
+	private final ApplicationEventPublisher applicationEventPublisher;
+
+	public TemperatureMonitor(ApplicationEventPublisher applicationEventPublisher) {
+
+		Assert.notNull(applicationEventPublisher, "ApplicationEventPublisher is required");
+
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+
+	@ContinuousQuery(name = "BoilingTemperatureMonitor",
+		query = "SELECT * FROM /TemperatureReadings WHERE temperature >= 212")
+	public void boilingTemperatureReadings(CqEvent event) {
+
+		Optional.ofNullable(event)
+			.map(CqEvent::getNewValue)
+			.filter(TemperatureReading.class::isInstance)
+			.map(TemperatureReading.class::cast)
+			.map(it -> new BoilingTemperatureEvent(this, it))
+			.ifPresent(this.applicationEventPublisher::publishEvent);
+	}
+
+	@ContinuousQuery(name = "FreezingTemperatureMonitor",
+		query = "SELECT * FROM /TemperatureReadings WHERE temperature <= 32")
+	public void freezingTemperatureReadings(CqEvent event) {
+
+		Optional.ofNullable(event)
+			.map(CqEvent::getNewValue)
+			.filter(TemperatureReading.class::isInstance)
+			.map(TemperatureReading.class::cast)
+			.map(it -> new FreezingTemperatureEvent(this, it))
+			.ifPresent(this.applicationEventPublisher::publishEvent);
+	}
+}

--- a/samples/boot/actuator/src/main/java/example/app/temp/service/TemperatureSensor.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/service/TemperatureSensor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/samples/boot/actuator/src/main/java/example/app/temp/service/TemperatureSensor.java
+++ b/samples/boot/actuator/src/main/java/example/app/temp/service/TemperatureSensor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package example.app.temp.service;
+
+import java.io.PrintStream;
+import java.util.PrimitiveIterator;
+import java.util.Random;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import example.app.temp.model.TemperatureReading;
+import example.app.temp.repo.TemperatureReadingRepository;
+
+@Service
+@SuppressWarnings("unused")
+public class TemperatureSensor {
+
+	private final PrimitiveIterator.OfInt temperatureStream = new Random(System.currentTimeMillis())
+		.ints(-100, 400).iterator();
+
+	private final TemperatureReadingRepository repository;
+
+	public TemperatureSensor(TemperatureReadingRepository repository) {
+
+		Assert.notNull(repository, "TemperatureReadingRepository is required");
+
+		this.repository = repository;
+	}
+
+	@Scheduled(fixedRateString = "${example.app.temp.sensor.reading.schedule.rate:1000}")
+	public void readTemperature() {
+		this.repository.save(log(TemperatureReading.newTemperatureReading(temperatureStream.nextInt())));
+	}
+
+	private TemperatureReading log(TemperatureReading temperatureReading) {
+
+		PrintStream out = temperatureReading.isNormal() ? System.out : System.err;
+
+		out.printf("TEMPERATURE READING [%s]%n", temperatureReading);
+
+		return temperatureReading;
+	}
+}

--- a/samples/boot/actuator/src/main/resources/application-client.properties
+++ b/samples/boot/actuator/src/main/resources/application-client.properties
@@ -1,0 +1,1 @@
+server.port=9191

--- a/samples/boot/actuator/src/main/resources/application-server.properties
+++ b/samples/boot/actuator/src/main/resources/application-server.properties
@@ -1,0 +1,1 @@
+server.port=8181

--- a/samples/boot/actuator/src/main/resources/application.properties
+++ b/samples/boot/actuator/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+management.endpoint.health.show-details=always
+#management.endpoints.web.exposure.include=env
+spring.data.gemfire.cache.log-level=error

--- a/spring-geode-actuator-autoconfigure/src/main/java/org/springframework/geode/boot/actuate/autoconfigure/GeodeHealthIndicatorAutoConfiguration.java
+++ b/spring-geode-actuator-autoconfigure/src/main/java/org/springframework/geode/boot/actuate/autoconfigure/GeodeHealthIndicatorAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator-autoconfigure/src/main/java/org/springframework/geode/boot/actuate/autoconfigure/config/BaseGeodeHealthIndicatorConfiguration.java
+++ b/spring-geode-actuator-autoconfigure/src/main/java/org/springframework/geode/boot/actuate/autoconfigure/config/BaseGeodeHealthIndicatorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator-autoconfigure/src/main/java/org/springframework/geode/boot/actuate/autoconfigure/config/ClientCacheHealthIndicatorConfiguration.java
+++ b/spring-geode-actuator-autoconfigure/src/main/java/org/springframework/geode/boot/actuate/autoconfigure/config/ClientCacheHealthIndicatorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator-autoconfigure/src/main/java/org/springframework/geode/boot/actuate/autoconfigure/config/PeerCacheHealthIndicatorConfiguration.java
+++ b/spring-geode-actuator-autoconfigure/src/main/java/org/springframework/geode/boot/actuate/autoconfigure/config/PeerCacheHealthIndicatorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator-autoconfigure/src/test/java/org/springframework/geode/boot/actuate/autoconfigure/GeodeCacheServerHealthIndicatorAutoConfigurationIntegrationTests.java
+++ b/spring-geode-actuator-autoconfigure/src/test/java/org/springframework/geode/boot/actuate/autoconfigure/GeodeCacheServerHealthIndicatorAutoConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeAsyncEventQueuesHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeAsyncEventQueuesHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeCacheHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeCacheHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeCacheServersHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeCacheServersHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeContinuousQueriesHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeContinuousQueriesHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeDiskStoresHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeDiskStoresHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeGatewayReceiversHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeGatewayReceiversHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeGatewaySendersHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeGatewaySendersHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeIndexesHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeIndexesHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodePoolsHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodePoolsHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeRegionsHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/GeodeRegionsHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/health/AbstractGeodeHealthIndicator.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/health/AbstractGeodeHealthIndicator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/health/support/ActuatorServerLoadProbeWrapper.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/health/support/ActuatorServerLoadProbeWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/health/support/RegionStatisticsResolver.java
+++ b/spring-geode-actuator/src/main/java/org/springframework/geode/boot/actuate/health/support/RegionStatisticsResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeAsyncEventQueuesHealthIndicatorUnitTests.java
+++ b/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeAsyncEventQueuesHealthIndicatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeCacheHealthIndicatorUnitTests.java
+++ b/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeCacheHealthIndicatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeCacheServersHealthIndicatorUnitTests.java
+++ b/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeCacheServersHealthIndicatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeContinuousQueriesHealthIndicatorUnitTests.java
+++ b/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeContinuousQueriesHealthIndicatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeDiskStoresHealthIndicatorUnitTests.java
+++ b/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeDiskStoresHealthIndicatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeGatewayReceiversHealthIndicatorUnitTests.java
+++ b/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeGatewayReceiversHealthIndicatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeGatewaySendersHealthIndicatorUnitTests.java
+++ b/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeGatewaySendersHealthIndicatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeIndexesHealthIndicatorUnitTests.java
+++ b/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeIndexesHealthIndicatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodePoolsHealthIndicatorUnitTests.java
+++ b/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodePoolsHealthIndicatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeRegionsHealthIndicatorUnitTests.java
+++ b/spring-geode-actuator/src/test/java/org/springframework/geode/boot/actuate/GeodeRegionsHealthIndicatorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/CacheNameAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/CacheNameAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/CachingProviderAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/CachingProviderAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/ClientCacheAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/ClientCacheAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/ClientSecurityAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/ClientSecurityAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/ContinuousQueryAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/ContinuousQueryAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/FunctionExecutionAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/FunctionExecutionAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/GemFireRepositoriesAutoConfigurationRegistrar.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/GemFireRepositoriesAutoConfigurationRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/PdxSerializationAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/PdxSerializationAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/PeerSecurityAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/PeerSecurityAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/RepositoriesAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/RepositoriesAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/SpringSessionAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/SpringSessionAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/SslAutoConfiguration.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/SslAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/condition/ConditionalOnMissingProperty.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/condition/ConditionalOnMissingProperty.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/condition/OnMissingPropertyCondition.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/condition/OnMissingPropertyCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/package-info.java
+++ b/spring-geode-autoconfigure/src/main/java/org/springframework/geode/boot/autoconfigure/package-info.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/app/NonBeanType.java
+++ b/spring-geode-autoconfigure/src/test/java/example/app/NonBeanType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/app/model/Author.java
+++ b/spring-geode-autoconfigure/src/test/java/example/app/model/Author.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/app/model/Book.java
+++ b/spring-geode-autoconfigure/src/test/java/example/app/model/Book.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/app/model/ISBN.java
+++ b/spring-geode-autoconfigure/src/test/java/example/app/model/ISBN.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/app/repo/BookRepository.java
+++ b/spring-geode-autoconfigure/src/test/java/example/app/repo/BookRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/app/service/BookService.java
+++ b/spring-geode-autoconfigure/src/test/java/example/app/service/BookService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/app/service/support/CachingBookService.java
+++ b/spring-geode-autoconfigure/src/test/java/example/app/service/support/CachingBookService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/echo/config/EchoClientConfiguration.java
+++ b/spring-geode-autoconfigure/src/test/java/example/echo/config/EchoClientConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/echo/config/EchoServerConfiguration.java
+++ b/spring-geode-autoconfigure/src/test/java/example/echo/config/EchoServerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/geode/cache/EchoCacheLoader.java
+++ b/spring-geode-autoconfigure/src/test/java/example/geode/cache/EchoCacheLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/geode/query/cq/event/TemperatureReading.java
+++ b/spring-geode-autoconfigure/src/test/java/example/geode/query/cq/event/TemperatureReading.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/geode/query/cq/event/TemperatureReadingsContinuousQueriesHandler.java
+++ b/spring-geode-autoconfigure/src/test/java/example/geode/query/cq/event/TemperatureReadingsContinuousQueriesHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/geode/query/cq/event/TemperatureUnit.java
+++ b/spring-geode-autoconfigure/src/test/java/example/geode/query/cq/event/TemperatureUnit.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/java/lang/ObjectToStringWithOptionalUnitTests.java
+++ b/spring-geode-autoconfigure/src/test/java/example/java/lang/ObjectToStringWithOptionalUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/example/java/net/UrlRevealed.java
+++ b/spring-geode-autoconfigure/src/test/java/example/java/net/UrlRevealed.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/cache/CacheNameAutoConfigurationIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/cache/CacheNameAutoConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/cache/client/SpringBootApacheGeodeClientCacheApplicationIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/cache/client/SpringBootApacheGeodeClientCacheApplicationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/cache/peer/SpringBootApacheGeodePeerCacheApplicationIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/cache/peer/SpringBootApacheGeodePeerCacheApplicationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/caching/AutoConfiguredCachingIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/caching/AutoConfiguredCachingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/caching/ManuallyConfiguredCachingIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/caching/ManuallyConfiguredCachingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/caching/ManuallyConfiguredWithPropertiesCachingIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/caching/ManuallyConfiguredWithPropertiesCachingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/condition/ConditionalOnMissingPropertyIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/condition/ConditionalOnMissingPropertyIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/cq/AutoConfiguredContinuousQueryIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/cq/AutoConfiguredContinuousQueryIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/function/AutoConfiguredFunctionExecutionsIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/function/AutoConfiguredFunctionExecutionsIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/function/executions/Calculator.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/function/executions/Calculator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/repository/AutoConfiguredRepositoriesIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/repository/AutoConfiguredRepositoriesIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/repository/model/Customer.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/repository/model/Customer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/repository/repo/CustomerRepository.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/repository/repo/CustomerRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/repository/service/CustomerService.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/repository/service/CustomerService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/auth/AbstractAutoConfiguredSecurityContextIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/auth/AbstractAutoConfiguredSecurityContextIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/auth/ClientSecurityAutoConfigurationUnitTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/auth/ClientSecurityAutoConfigurationUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/auth/cloud/AutoConfiguredCloudSecurityContextIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/auth/cloud/AutoConfiguredCloudSecurityContextIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/auth/local/AutoConfiguredLocalSecurityContextIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/auth/local/AutoConfiguredLocalSecurityContextIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/ssl/AutoConfiguredSslIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/ssl/AutoConfiguredSslIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/ssl/SslAutoConfigurationUnitTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/security/ssl/SslAutoConfigurationUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/AutoConfiguredSessionCachingIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/AutoConfiguredSessionCachingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/AutoConfiguredSessionRemoteCachingIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/AutoConfiguredSessionRemoteCachingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/CustomConfiguredSessionCachingIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/CustomConfiguredSessionCachingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/ManuallyConfiguredSessionCachingIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/ManuallyConfiguredSessionCachingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/ManuallyConfiguredWithPropertiesSessionCachingIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/ManuallyConfiguredWithPropertiesSessionCachingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/NoAutoConfigurationOfSessionCachingIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/NoAutoConfigurationOfSessionCachingIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/SessionExpirationIntegrationTests.java
+++ b/spring-geode-autoconfigure/src/test/java/org/springframework/geode/boot/autoconfigure/session/SessionExpirationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode-docs/spring-geode-docs.gradle
+++ b/spring-geode-docs/spring-geode-docs.gradle
@@ -43,12 +43,12 @@ asciidoctor {
 javadoc {
 	configure(options) {
 		links = [
-			"http://docs.spring.io/spring/docs/current/javadoc-api/",
+			"https://docs.spring.io/spring/docs/current/javadoc-api/",
 			"https://docs.spring.io/spring-boot/docs/current/api/",
-			"http://docs.spring.io/spring-data/commons/docs/current/api/",
+			"https://docs.spring.io/spring-boot-data-geode/docs/${project.version}/api/",
+			"https://docs.spring.io/spring-data/commons/docs/current/api/",
 			"https://docs.spring.io/spring-data/geode/docs/current/api/",
-			"http://docs.spring.io/spring-boot-data-geode/docs/${project.version}/api/",
-			"http://geode.apache.org/releases/latest/javadoc/",
+			"https://geode.apache.org/releases/latest/javadoc/",
 		]
 	}
 }

--- a/spring-geode-docs/src/docs/asciidoc/appendix.adoc
+++ b/spring-geode-docs/src/docs/asciidoc/appendix.adoc
@@ -82,7 +82,7 @@ SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further detail
   (the "License"); you may not use this file except in compliance with the
   License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/spring-geode-docs/src/main/java/org/springframework/geode/docs/example/app/server/SpringBootApacheGeodeCacheServerApplication.java
+++ b/spring-geode-docs/src/main/java/org/springframework/geode/docs/example/app/server/SpringBootApacheGeodeCacheServerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/cache/support/CacheLoaderSupport.java
+++ b/spring-geode/src/main/java/org/springframework/geode/cache/support/CacheLoaderSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/config/annotation/DistributedSystemIdConfiguration.java
+++ b/spring-geode/src/main/java/org/springframework/geode/config/annotation/DistributedSystemIdConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/config/annotation/DurableClientConfiguration.java
+++ b/spring-geode/src/main/java/org/springframework/geode/config/annotation/DurableClientConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/config/annotation/EnableDurableClient.java
+++ b/spring-geode/src/main/java/org/springframework/geode/config/annotation/EnableDurableClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/config/annotation/GroupsConfiguration.java
+++ b/spring-geode/src/main/java/org/springframework/geode/config/annotation/GroupsConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/config/annotation/LocatorsConfiguration.java
+++ b/spring-geode/src/main/java/org/springframework/geode/config/annotation/LocatorsConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/config/annotation/MemberNameConfiguration.java
+++ b/spring-geode/src/main/java/org/springframework/geode/config/annotation/MemberNameConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/config/annotation/UseDistributedSystemId.java
+++ b/spring-geode/src/main/java/org/springframework/geode/config/annotation/UseDistributedSystemId.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/config/annotation/UseGroups.java
+++ b/spring-geode/src/main/java/org/springframework/geode/config/annotation/UseGroups.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/config/annotation/UseLocators.java
+++ b/spring-geode/src/main/java/org/springframework/geode/config/annotation/UseLocators.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/config/annotation/UseMemberName.java
+++ b/spring-geode/src/main/java/org/springframework/geode/config/annotation/UseMemberName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/core/env/VcapPropertySource.java
+++ b/spring-geode/src/main/java/org/springframework/geode/core/env/VcapPropertySource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/core/env/support/CloudCacheService.java
+++ b/spring-geode/src/main/java/org/springframework/geode/core/env/support/CloudCacheService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/core/env/support/Service.java
+++ b/spring-geode/src/main/java/org/springframework/geode/core/env/support/Service.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/core/env/support/User.java
+++ b/spring-geode/src/main/java/org/springframework/geode/core/env/support/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/core/util/ObjectUtils.java
+++ b/spring-geode/src/main/java/org/springframework/geode/core/util/ObjectUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/function/config/AbstractFunctionExecutionAutoConfigurationExtension.java
+++ b/spring-geode/src/main/java/org/springframework/geode/function/config/AbstractFunctionExecutionAutoConfigurationExtension.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/function/config/GemFireFunctionExecutionAutoConfigurationRegistrar.java
+++ b/spring-geode/src/main/java/org/springframework/geode/function/config/GemFireFunctionExecutionAutoConfigurationRegistrar.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/function/support/AbstractResultCollector.java
+++ b/spring-geode/src/main/java/org/springframework/geode/function/support/AbstractResultCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/function/support/SingleResultReturningCollector.java
+++ b/spring-geode/src/main/java/org/springframework/geode/function/support/SingleResultReturningCollector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/security/support/SecurityManagerProxy.java
+++ b/spring-geode/src/main/java/org/springframework/geode/security/support/SecurityManagerProxy.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/main/java/org/springframework/geode/security/support/SecurityManagerSupport.java
+++ b/spring-geode/src/main/java/org/springframework/geode/security/support/SecurityManagerSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/config/annotation/DistributedSystemIdConfigurationIntegrationTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/config/annotation/DistributedSystemIdConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/config/annotation/DurableClientConfigurationIntegrationTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/config/annotation/DurableClientConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/config/annotation/GroupsConfigurationIntegrationTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/config/annotation/GroupsConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/config/annotation/LocatorsConfigurationIntegrationTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/config/annotation/LocatorsConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/config/annotation/MemberNameConfigurationIntegrationTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/config/annotation/MemberNameConfigurationIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/config/annotation/MemberNameOverridesCacheNameIntegrationTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/config/annotation/MemberNameOverridesCacheNameIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/core/env/VcapPropertySourceUnitTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/core/env/VcapPropertySourceUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/core/env/support/CloudCacheServiceUnitTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/core/env/support/CloudCacheServiceUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/core/env/support/ServiceUnitTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/core/env/support/ServiceUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/core/env/support/UserUnitTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/core/env/support/UserUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/core/util/ObjectUtilsUnitTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/core/util/ObjectUtilsUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/function/support/AbstractResultCollectorUnitTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/function/support/AbstractResultCollectorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/function/support/SingleResultReturningCollectorUnitTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/function/support/SingleResultReturningCollectorUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/security/support/SecurityManagerProxyIntegrationTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/security/support/SecurityManagerProxyIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-geode/src/test/java/org/springframework/geode/security/support/SecurityManagerProxyUnitTests.java
+++ b/spring-geode/src/test/java/org/springframework/geode/security/support/SecurityManagerProxyUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 134 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0.html with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.html ([https](https://www.apache.org/licenses/LICENSE-2.0.html) result 200).