### PR TITLE
Fix minor spelling error 'grade' -> 'gradle'

### DIFF
--- a/spring-geode-docs/src/docs/asciidoc/index.adoc
+++ b/spring-geode-docs/src/docs/asciidoc/index.adoc
@@ -144,7 +144,7 @@ To use Spring Boot for Apache Geode, declare the `spring-geode-starter` on your 
 </dependencies
 ----
 
-.Grade
+.Gradle
 [source,java]
 [subs="verbatim,attributes"]
 ----


### PR DESCRIPTION
I happened to catch a small (but critical) spelling error in the setup page.