### PR TITLE
Update .gitignore with bin/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 out/
 target/
+bin/
 .gradle
 .springBeans
 *.iml


### PR DESCRIPTION
I'm getting these bin/ directories from adding the project from the top of the geode project. 

spring-gemfire-starter/bin/
	spring-geode-actuator-autoconfigure/bin/
	spring-geode-actuator/bin/
	spring-geode-autoconfigure/bin/
	spring-geode-docs/bin/
	spring-geode-samples/boot/actuator/bin/
	spring-geode-samples/boot/configuration/.java-version
	spring-geode-samples/boot/configuration/bin/
	spring-geode-samples/boot/security/bin/
	spring-geode-samples/caching/http-session/bin/
	spring-geode-samples/caching/inline/bin/
	spring-geode-samples/caching/look-aside/bin/
	spring-geode-samples/caching/multi-site/bin/
	spring-geode-samples/caching/near/bin/
	spring-geode-samples/intro/getting-started/bin/
	spring-geode-samples/land-shy-fan/
	spring-geode-samples/lock-important-pot/
	spring-geode-samples/mix-faithful-pot/
	spring-geode-starter-logging/bin/
	spring-geode-tests/smoke-tests/function-execution-on-region/bin/
	spring-geode-tests/smoke-tests/locator-application/bin/
	spring-geode-tests/smoke-tests/logging/bin/
	spring-geode-tests/smoke-tests/multi-store/bin/
	spring-geode-tests/smoke-tests/peer-cache-application/bin/
	spring-geode-tests/smoke-tests/spring-initializer/bin/
	spring-geode/bin/

I'm adding bin/ to remove those.