### PR TITLE
Update Manager Applications Documentation

### DIFF
--- a/spring-geode-docs/src/docs/asciidoc/_includes/clientcache-applications.adoc
+++ b/spring-geode-docs/src/docs/asciidoc/_includes/clientcache-applications.adoc
@@ -694,6 +694,7 @@ The required dependencies are:
 ----
 runtime "org.apache.geode:geode-http-service"
 runtime "org.apache.geode:geode-web"
+runtime "org.apache.geode:geode-pulse"
 runtime "org.springframework.boot:spring-boot-starter-jetty"
 ----
 
@@ -703,3 +704,5 @@ which is used by tooling, such as _Gfsh_, to connect to the cluster over HTTP.  
 
 Even if you do not start the embedded HTTP service (Jetty Servlet Container), a _Manager_ still requires
 the `geode-http-service`, `geode-web` and `spring-boot-starter-jetty` dependencies.
+The `geode-pulse` dependency, on the contrary, is only required if you want the _Manager_ to automatically start
+the {apache-geode-docs}/tools_modules/pulse/pulse-overview.html[Pulse] Monitoring Tool


### PR DESCRIPTION
Add geode-pulse as a dependency in the documentation for those users
that want to automatically start the PULSE application embedded within
the manager.